### PR TITLE
Fix header toggle wrapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,18 +10,20 @@
 </head>
 <body>
   <div class="container">
-    <header class="site-header">
-      <h1 class="site-title">drs-az</h1>
-      <nav class="site-nav">
-        <a href="#projects">Projects</a>
-        <a href="#prompts">Prompts</a>
-        <a href="https://github.com/drs-az" target="_blank" rel="noopener noreferrer">GitHub</a>
-      </nav>
-      <button class="theme-toggle" onclick="toggleTheme()">
-        <span class="light-icon">☀️</span>
-        <span class="dark-icon">🌙</span>
-      </button>
-    </header>
+      <header class="site-header">
+        <h1 class="site-title">drs-az</h1>
+        <div class="nav-wrapper">
+          <nav class="site-nav">
+            <a href="#projects">Projects</a>
+            <a href="#prompts">Prompts</a>
+            <a href="https://github.com/drs-az" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </nav>
+          <button class="theme-toggle" onclick="toggleTheme()">
+            <span class="light-icon">☀️</span>
+            <span class="dark-icon">🌙</span>
+          </button>
+        </div>
+      </header>
 
     <section class="hero">
       <h2>Crafting AI prompts and web experiments</h2>

--- a/styles.css
+++ b/styles.css
@@ -82,8 +82,14 @@ a:hover {
   border-bottom: 1px solid var(--border-color);
 }
 
-.site-nav {
+.nav-wrapper {
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.site-nav {
   display: flex;
   gap: 1.5rem;
   font-family: var(--font-body);
@@ -223,6 +229,16 @@ html[data-theme="dark"] .theme-toggle .dark-icon { display: inline-block; }
     gap: 1rem;
   }
 
+  .nav-wrapper {
+    width: 100%;
+    margin-left: 0;
+    justify-content: space-between;
+  }
+
+  .site-nav {
+    gap: 1rem;
+  }
+
   .site-title {
     font-size: 2rem;
   }
@@ -271,6 +287,10 @@ html[data-theme="dark"] .theme-toggle .dark-icon { display: inline-block; }
   }
   .site-title {
     font-size: 1.8rem;
+  }
+  .nav-wrapper {
+    flex-wrap: wrap;
+    gap: 0.5rem;
   }
   .theme-toggle {
     padding: 0.4rem 0.8rem;


### PR DESCRIPTION
## Summary
- keep nav links and toggle together under a new `.nav-wrapper`
- adjust responsive styles so the dark/light toggle stays on the same row

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_6876a7463f2c8331a1761d8af57a7814