### PR TITLE
Add blog page with dark/light mode

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>drs-az Blog</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡️</text></svg>">
+</head>
+<body>
+  <div class="container">
+      <header class="site-header">
+        <h1 class="site-title">drs-az</h1>
+        <div class="nav-wrapper">
+          <nav class="site-nav">
+            <a href="index.html">Home</a>
+            <a href="blog.html" class="active">Blog</a>
+            <a href="https://github.com/drs-az" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </nav>
+          <button class="theme-toggle" onclick="toggleTheme()">
+            <span class="light-icon">☀️</span>
+            <span class="dark-icon">🌙</span>
+          </button>
+        </div>
+      </header>
+
+      <main class="blog-posts">
+        <article class="blog-post">
+          <h2>Welcome to My Blog</h2>
+          <p>Here I'll share thoughts on my projects, AI experimentation, and anything else that sparks my interest.</p>
+        </article>
+        <article class="blog-post">
+          <h2>First Entry</h2>
+          <p>This is a starter post for the new blog section. Stay tuned for updates!</p>
+        </article>
+      </main>
+
+      <footer class="footer">
+        <p>&copy; 2025 drs-az</p>
+      </footer>
+  </div>
+
+  <script>
+    function toggleTheme() {
+      const html = document.documentElement;
+      const newTheme = html.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+      html.setAttribute('data-theme', newTheme);
+      localStorage.setItem('theme', newTheme);
+    }
+
+    (function() {
+      const saved = localStorage.getItem('theme');
+      const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      let initialTheme = 'light';
+      if (saved) {
+        initialTheme = saved;
+      } else if (systemPrefersDark) {
+        initialTheme = 'dark';
+      }
+      document.documentElement.setAttribute('data-theme', initialTheme);
+    })();
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>drs-az – Projects & Prompts</title>
+  <title>drs-az – AI Projects &amp; Blog</title>
   <link rel="stylesheet" href="styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚡️</text></svg>">
@@ -16,6 +16,7 @@
           <nav class="site-nav">
             <a href="#projects">Projects</a>
             <a href="#prompts">Prompts</a>
+            <a href="blog.html">Blog</a>
             <a href="https://github.com/drs-az" target="_blank" rel="noopener noreferrer">GitHub</a>
           </nav>
           <button class="theme-toggle" onclick="toggleTheme()">
@@ -26,8 +27,8 @@
       </header>
 
     <section class="hero">
-      <h2>LLM and Technology Experiments</h2>
-      <p class="hero-text">Welcome! I'm <a href="https://github.com/drs-az" target="_blank" rel="noopener noreferrer">drs-az</a>, and this site gathers my explorations with large language models alongside other small projects.</p>
+      <h2>AI Experiments &amp; Web Projects</h2>
+      <p class="hero-text">This site showcases my experiments with AI, web development, and creative technology.</p>
     </section>
 
     <main class="projects-grid">

--- a/styles.css
+++ b/styles.css
@@ -95,6 +95,10 @@ a:hover {
   font-family: var(--font-body);
 }
 
+.site-nav a.active {
+  font-weight: 600;
+}
+
 .site-title {
   font-family: var(--font-heading);
   font-size: 2.5rem;
@@ -189,6 +193,35 @@ html[data-theme="dark"] .theme-toggle .dark-icon { display: inline-block; }
 }
 
 .project-description {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--text-color);
+}
+
+/* --- Blog Styles --- */
+.blog-posts {
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.blog-post {
+  background-color: var(--bg-color);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 1.8rem;
+  box-shadow: 0 2px 10px var(--shadow-color);
+}
+
+.blog-post h2 {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  color: var(--accent-color);
+  margin-bottom: 0.5rem;
+}
+
+.blog-post p {
   font-size: 1.05rem;
   line-height: 1.6;
   color: var(--text-color);


### PR DESCRIPTION
## Summary
- refresh hero heading and tagline
- add `Blog` link to navigation
- create standalone `blog.html`
- style blog post layout and active nav links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ab7a1fa6c8331a33201a6b0d8f00e